### PR TITLE
Update to Android SDK 36 and add Nix build support

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,8 +16,8 @@
         };
         
         androidComposition = pkgs.androidenv.composeAndroidPackages {
-          buildToolsVersions = [ "34.0.0" "33.0.2" ];
-          platformVersions = [ "34" "33" ];
+          buildToolsVersions = [ "35.0.0" ];
+          platformVersions = [ "36" ];
           abiVersions = [ "x86_64" "arm64-v8a" ];
           includeNDK = true;
           ndkVersions = [ "25.2.9519653" ];
@@ -31,8 +31,26 @@
         };
 
         androidSdk = androidComposition.androidsdk;
+        
+        buildScript = pkgs.writeShellScriptBin "build-magnifier" ''
+          set -e
+          export ANDROID_HOME=${androidSdk}/libexec/android-sdk
+          export ANDROID_SDK_ROOT=$ANDROID_HOME
+          export JAVA_HOME=${pkgs.jdk17}
+          export PATH=$ANDROID_HOME/cmdline-tools/latest/bin:$ANDROID_HOME/platform-tools:$PATH
+          
+          cd magnifier-app
+          echo "Building Android APK..."
+          ./gradlew assembleRelease --no-daemon
+          
+          echo "APK built successfully!"
+          echo "Location: $(realpath app/build/outputs/apk/release/*.apk)"
+        '';
       in
       {
+        packages.default = buildScript;
+        packages.build-magnifier = buildScript;
+        
         devShells.default = pkgs.mkShell {
           buildInputs = with pkgs; [
             # Android SDK

--- a/magnifier-app/app/build.gradle.kts
+++ b/magnifier-app/app/build.gradle.kts
@@ -5,12 +5,12 @@ plugins {
 
 android {
     namespace = "com.example.magnifier"
-    compileSdk = 34
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "com.example.magnifier"
         minSdk = 24
-        targetSdk = 34
+        targetSdk = 36
         versionCode = 1
         versionName = "1.0"
 

--- a/magnifier-app/app/src/main/java/com/example/magnifier/MainActivity.kt
+++ b/magnifier-app/app/src/main/java/com/example/magnifier/MainActivity.kt
@@ -183,7 +183,7 @@ class MainActivity : AppCompatActivity() {
     }
     
     private fun invertColors(bitmap: Bitmap): Bitmap {
-        val inverted = Bitmap.createBitmap(bitmap.width, bitmap.height, bitmap.config)
+        val inverted = Bitmap.createBitmap(bitmap.width, bitmap.height, bitmap.config ?: Bitmap.Config.ARGB_8888)
         val canvas = Canvas(inverted)
         val paint = Paint()
         


### PR DESCRIPTION
- Update compileSdk and targetSdk from 34 to 36
- Add Android SDK platform 36 and build tools 35.0.0 to flake.nix
- Remove older SDK versions to reduce environment size
- Add build-magnifier Nix package for building APK with proper environment setup
- Fix Kotlin null safety issue in MainActivity.kt bitmap.config usage
- Successfully tested Nix build generating release APK

🤖 Generated with [Claude Code](https://claude.ai/code)