### PR TITLE
Fix GitHub Actions release workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
       - 'v*'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   build-release:


### PR DESCRIPTION
- Add explicit 'contents: write' permission to release workflow
- Resolves 403 error when creating GitHub releases
- Allows workflow to create releases and upload APK artifacts

🤖 Generated with [Claude Code](https://claude.ai/code)