### PR TITLE
Fix GitHub Actions permissions for gradle wrapper update workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   update-gradle-wrapper:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     
     steps:
     - name: Checkout code


### PR DESCRIPTION
Add proper permissions (contents: write, pull-requests: write) to the update-gradle-wrapper job to resolve 403 errors when creating pull requests.

🤖 Generated with [Claude Code](https://claude.ai/code)