### PR TITLE
build: bump compileSdk to 37 to unblock androidx updates

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1768773494,
-        "narHash": "sha256-XsM7GP3jHlephymxhDE+/TKKO1Q16phz/vQiLBGhpF4=",
+        "lastModified": 1784796856,
+        "narHash": "sha256-wWFrV5/Qbm+lyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "77ef7a29d276c6d8303aece3444d61118ef71ac2",
+        "rev": "e2587caef70cea85dd97d7daab492899902dbf5d",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-25.11",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Android development environment";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.11";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
@@ -17,7 +17,7 @@
 
         androidComposition = pkgs.androidenv.composeAndroidPackages {
           buildToolsVersions = [ "36.0.0" ];
-          platformVersions = [ "36" ];
+          platformVersions = [ "36" "37" ];
           abiVersions = [ "x86_64" "arm64-v8a" ];
           includeNDK = true;
           ndkVersions = [ "25.2.9519653" ];

--- a/magnifier-app/app/build.gradle.kts
+++ b/magnifier-app/app/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 android {
     namespace = "com.example.magnifier"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "com.example.magnifier"


### PR DESCRIPTION
## Why
Dependabot PRs #87 (`androidx.core:core-ktx` 1.19.0) and #90 (`androidx.lifecycle` 2.11.0) fail CI because those libraries require `compileSdk >= 37`, while the app is on `compileSdk = 36`.

## What
- `magnifier-app/app/build.gradle.kts`: `compileSdk` 36 → 37 (`targetSdk` left at 36).
- `flake.nix`: nixpkgs input `nixos-25.11` → `nixos-unstable`, and add platform `37` to `platformVersions`. The `nixos-25.11` androidenv only packages up to platform 36, so the local `nix develop` build couldn't provide platform 37; unstable has it.
- `flake.lock`: regenerated for the new nixpkgs.

## Verification
`nix develop --command ./gradlew build` (in `magnifier-app`) → **BUILD SUCCESSFUL** with the new toolchain and `compileSdk = 37`.

After this merges, #87 and #90 need a `@dependabot rebase` to pick up the new base and go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)